### PR TITLE
Potman pkg update fix and minipot temp work-around

### DIFF
--- a/commands/init.sh
+++ b/commands/init.sh
@@ -126,6 +126,12 @@ cat >site.yml<<"EOF"
       content: |
         FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest" }
 
+  - name: Update package metadata
+    ansible.builtin.command: pkg update -f
+
+  - name: Upgrade existing packages (incl. pkg)
+    ansible.builtin.command: pkg upgrade -y
+
   - name: Install packages
     ansible.builtin.package:
       name:
@@ -287,6 +293,12 @@ cat >site.yml<<"EOF"
 
     notify:
       - Restart consul
+
+  - name: Update nomad_args sysrc
+    ansible.builtin.command: sysrc nomad_args+=" -data-dir=/var/tmp/nomad"
+
+    notify:
+      - Restart nomad
 
   handlers:
   - name: Restart nomad

--- a/commands/init.sh
+++ b/commands/init.sh
@@ -294,13 +294,11 @@ cat >site.yml<<"EOF"
     notify:
       - Restart consul
 
-  - name: Update nomad_args sysrc
-    ansible.builtin.command: sysrc nomad_args+=" -data-dir=/var/tmp/nomad"
-
-    notify:
-      - Restart nomad
-
   handlers:
+  - name: sysrc fix
+    ansible.builtin.command: sysrc nomad_args+=" -data-dir=/var/tmp/nomad"
+    listen: Restart nomad
+
   - name: Restart nomad
     ansible.builtin.service:
       name: nomad


### PR DESCRIPTION
```yml
  - name: sysrc fix
    ansible.builtin.command: sysrc nomad_args+=" -data-dir=/var/tmp/nomad"
    listen: Restart nomad
```

Will need to be removed after `bsdpot/minipot` receives a fix mentioned [here](https://github.com/bsdpot/minipot/pull/3)