### PR TITLE
Upgrade potman to FreeBSD 13.3

### DIFF
--- a/commands/common.sh
+++ b/commands/common.sh
@@ -5,7 +5,7 @@ set -e
 VERSION_REGEX='^[0-9](\.[0-9a-zA-Z_-]+)*$'
 ORIGIN_REGEX='^([a-zA-Z0-9_]*)$'
 KILN_NAME_REGEX='^[a-zA-Z]([0-9a-zA-Z]+)*$'
-FREEBSD_VERSION_REGEX='^(12\.4|13\.2)$'
+FREEBSD_VERSION_REGEX='^(12\.4|13\.2|13\.3)$'
 # poor
 NETWORK_REGEX='^([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$'
 # shellcheck disable=SC2034

--- a/commands/init.sh
+++ b/commands/init.sh
@@ -11,11 +11,11 @@ usage()
 
     flavourdir defaults to 'flavours'
     network defaults to '10.100.1'
-    freebd_version defaults to '13.2'
+    freebd_version defaults to '13.3'
 "
 }
 
-FREEBSD_VERSION=13.2
+FREEBSD_VERSION=13.3
 FLAVOURS_DIR=flavours
 
 OPTIND=1


### PR DESCRIPTION
Have tested some builds without issue so I feel that `potman` can be upgraded to `13.3`

Have not tested [packer-FreeBSD](https://github.com/jlduran/packer-FreeBSD)  commit [6738c6f](https://github.com/jlduran/packer-FreeBSD/commit/6738c6f477a8a4644649fcf56f918cfbac956e54) which is for `14.4` so left it as is.