### PR TITLE
Update freebsd flavour and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ In the example below, we're building the git-nomad flavour.
 
 Get potluck:
 
-    git clone https://codeberg.org/bsdpot/potluck.git
+    git clone https://codeberg.org/bsdpot/potluck
 
 Prepare potman:
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Build [pots](https://github.com/pizzamig/pot) easily.
 
 Uses [Potluck](https://potluck.honeyguide.net) templates, see also
-the [Potluck Flavour Repository](https://github.com/hny-gd/potluck) and
+the [Potluck Flavour Repository](https://codeberg.org/bsdpot/potluck.git) and
 [FreeBSD Virtual DC with Potluck](https://honeyguide.eu/posts/virtual-dc1/).
 
 ## Quickstart
@@ -90,7 +90,7 @@ potman requires
 Installing these depends on your OS/distribution, on FreeBSD the procedure
 is:
 
-    pkg install bash git packer py39-ansible py39-packaging \
+    pkg install bash git packer py311-ansible py311-packaging \
       vagrant virtualbox-ose
     service vboxnet enable
     service vboxnet start
@@ -144,7 +144,7 @@ In the example below, we're building the git-nomad flavour.
 
 Get potluck:
 
-    git clone https://github.com/hny-gd/potluck
+    git clone https://codeberg.org/bsdpot/potluck.git
 
 Prepare potman:
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Build [pots](https://github.com/pizzamig/pot) easily.
 
 Uses [Potluck](https://potluck.honeyguide.net) templates, see also
-the [Potluck Flavour Repository](https://codeberg.org/bsdpot/potluck.git) and
+the [Potluck Flavour Repository](https://codeberg.org/bsdpot/potluck) and
 [FreeBSD Virtual DC with Potluck](https://honeyguide.eu/posts/virtual-dc1/).
 
 ## Quickstart

--- a/flavours/freebsd/freebsd.sh
+++ b/flavours/freebsd/freebsd.sh
@@ -92,7 +92,7 @@ step "Install joe"
 pkg install -y joe
 
 step "Install common large packages"
-pkg install -y python38 perl5
+pkg install -y python311 perl5
 
 step "Clean package installation"
 pkg clean -y


### PR DESCRIPTION
- python38 has been unregistered from freebsd ports
  Ref [ca15850a2b13f4fede0294d724e1d4a8edec8407](https://cgit.freebsd.org/ports/commit/?id=ca15850a2b13f4fede0294d724e1d4a8edec8407)
- Potluck has migrated from github to codeberg
- Match python version in readme to freebsd flavour